### PR TITLE
add moaifiddle

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,7 @@ Note: From LuaJIT to Lua to lua.vm.js to Moonshine, a basic benchmark sees perfo
   - [lurker](https://github.com/rxi/lurker) - Shortens the iteration cycle by auto-swapping changed Lua files in a running LÖVE project.
 - [Jumper](https://github.com/Yonaba/Jumper) - Fast, lightweight, and easy-to-use pathfinding library for grid-based games.
 - [lume](https://github.com/rxi/lume/) - Utility belt library geared toward game development.
+- [moaifiddle](http://moaifiddle.com) - Edit and share short scripts for the MOAI game engine and run them in the browser using WebGL. 
 - [NoobHub](https://github.com/Overtorment/NoobHub) - Network multiplayer for Corona, LÖVE, and more, following a simple pub-sub model.
 - Collision detection
   - [bump.lua](https://github.com/kikito/bump.lua) - Minimal rectangle-based collision detection which handles tunnelling and basic collision resolution.


### PR DESCRIPTION
I saw the other game related stuff and the lua.vm.js mention and thought this might be handy. It is geared towards the moai game engine but since it is just lua it also works fine for normal lua code. Includes an entire port of the moai game engine to js using emscripten and including lua, in browser editor, a repl, and a virtual filesystem. Does this sort of fit with what you are after? source is at github.com/halfnelson/moaifiddle
