### PR TITLE
Add argparse

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -146,7 +146,7 @@ Search this page for 'OpenResty' to find related packages under other categories
 - [ansicolors](https://github.com/kikito/ansicolors.lua) - Simple function for printing to the console in color.
 - [cliargs](https://github.com/amireh/lua_cliargs) - A simple command-line argument parsing module.
 - [lua-term](https://github.com/hoelzro/lua-term) - Terminal operations and manipulations.
-
+- [argparse](https://github.com/mpeterv/argparse) - A feature-rich command line parser inspired by argparse for Python.
 
 ### Concurrency and Multithreading
 - Coroutine-based multitasking:


### PR DESCRIPTION
Argparse is an actively-maintained argument parsing module inspired by Python's argparse module.
Repo: https://github.com/mpeterv/argparse
Tutorial: https://mpeterv.github.io/argparse/
LuaRocks Package: https://rocks.moonscript.org/modules/mpeterv/argparse