### PR TITLE
Added Cloudsmith (Package Management SaaS)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,7 @@ Note: From LuaJIT to Lua to lua.vm.js to Moonshine, a basic benchmark sees perfo
 
 ### Package Managers
 - [LuaRocks](https://luarocks.org/) - De-facto tool for installing Lua modules as packages called "rocks", plus public rock repository and website.  Much like npm or pip.
-
+- [Cloudsmith](https://cloudsmith.io/l/luarocks-repository/) - A fully managed package management SaaS with support for LuaRocks (and many others).
 
 ### Build Tools and Standalone Makers
 - [Lake](https://github.com/stevedonovan/Lake) - A build engine written in Lua, similar to Ruby's rake.


### PR DESCRIPTION
[Cloudsmith](https://cloudsmith.io/l/luarocks-repository/) - This PR adds a link to [Cloudsmith](https://cloudsmith.io), which is a package management service SaaS. It's commercial, but it is completely free for open-source and it has generous free tiers otherwise. It has recently added support for LuaRocks, based on requests from the community; plus support for org/teams management, granular access controls, private repositories, repository-specific entitlements, a worldwide content distribution network, webhooks, access logs, etc. It should be extremely useful for anyone depending on, deploying with or distributing their own private (or public) LuaRocks modules.

*Full disclosure:* I work at/for Cloudsmith (and love it!) 🎉 🌟