### PR TITLE
add neovim

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -349,6 +349,7 @@ For more on the differences (particularly between `lanes` and `luaproc`), see th
 - [AwesomeWM](https://awesomewm.org/) - A highly configurable and extensible window manager for X, scripted and configured by Lua.
 - [Textadept](https://foicica.com/textadept/) - Extremely lightweight, customizable, cross-platform editor, written (mostly) in (and scripted by) Lua.
 - [KoReader](https://github.com/koreader/koreader) - An ebook reader application supports PDF, DJVU, EPUB, FB2 and much more, running on Kindle, Kobo, PocketBook and Android devices.
+- [Neovim](https://neovim.io/) - Vim fork focused on extensibility and usability
 
 
 ### Miscellaneous


### PR DESCRIPTION
Adding Neovim to "scriptable by" category.

It should be added because Neovim is focusing on adding Lua-scripting support as an alternative to Vimscript, and there are already quite a few Neovim plug-ins written solely in Lua. Neovim uses Lua 5.1.