### PR TITLE
Change 'Learn lua in 15 minutes' link to 'Learn Lua in Y Minutes'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -386,7 +386,7 @@ For more on the differences (particularly between `lanes` and `luaproc`), see th
 
 ### Tutorials
 - [Lua Crash Course](http://www.coppeliarobotics.com/helpFiles/en/luaCrashCourse.htm) - Short crash course readover, or reference for when you forget the basics.
-- [Learn Lua in 15 Minutes](http://tylerneylon.com/a/learn-lua/) - A well-commented example file which covers the basics.
+- [Learn Lua in Y Minutes](https://learnxinyminutes.com/docs/lua/) - A well-commented example file which covers the basics.
 - [Learning Lua from JS](http://phrogz.net/lua/LearningLua_FromJS.html) - An overview of the similarities and differences between Lua and JS; a great start for JavaScript folks looking to pick up Lua.
 - [lua-users tutorial](http://lua-users.org/wiki/LuaTutorial) - In-depth collection of tutorials aimed at newcomers.
 - [Lua Missions](https://github.com/kikito/lua_missions) - A series of 'Missions' to work through which are designed to teach aspects of Lua along the way.


### PR DESCRIPTION
'Learn lua in 15 minutes' seems to be an older link to the authors blog. The page on learnxinyminutes.com was actually submitted by Tyler Neylon (the creator of 'learn lua in 15 minutes') himself, and considering that the website is more popular, and open source, it will likely be more up-to-date.