### PR TITLE
Add a second static site generator

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -354,7 +354,7 @@ For more on the differences (particularly between `lanes` and `luaproc`), see th
 ### Miscellaneous
 - [MoonScript](http://moonscript.org/) - Moonscript is a dynamic scripting language that compiles to Lua. It reduces verbosity and provides a rich set of features like comprehensions and classes. Its author calls it 'CoffeeScript for Lua'.
 - [sitegen](http://leafo.net/sitegen/) - A static site generator which uses MoonScript and supports HTML and Markdown, page grouping, and plugins.
-
+- [gen_site](https://git.sr.ht/~akkartik/gen_site) - A minimalist static site generator for people willing to edit raw HTML.
 
 ## Resources
 


### PR DESCRIPTION
I've not been able to find an authoritative static site generator for Lua, so am suggesting something I've been using for several years that I just published. Works with Lua 5.1-5.4, requires no other dependencies. Unlike most such tools, this doesn't take on additional dependencies to support markdown. Instead I build my website https://akkartik.name using raw HTML.

If one is willing to edit HTML, what can an SSG provide? The answers I've come up with so far are:
* Giving pages on a site a shared look and feel using a minimal template.
* Stitching pages together into index pages with pagination.
* Autogenerating RSS and [HTML Journal](https://journal.miso.town) feeds so readers can be notified of new posts.

This tool provides one 150 line script for each of these concerns. Each script can be used independently of the others. For example I generate two sets of index pages on my site.