### PR TITLE
Add pandoc-a2ml and pandoc-k9 to Parsing and Serialization

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -264,6 +264,9 @@ For more on the differences (particularly between `lanes` and `luaproc`), see th
 - [lunamark](https://github.com/jgm/lunamark) - Converts Markdown to other textual formats including HTML and LaTeX. Uses LPeg for fast parsing.
 - [LXSH](https://github.com/xolox/lua-lxsh) - A collection of lexers and syntax highlighters written with LPeg.
 - [lua-pb](https://github.com/Neopallium/lua-pb) - Protocol Buffers implementation.
+- Pandoc Filters
+  - [pandoc-a2ml](https://github.com/hyperpolymath/pandoc-a2ml) - Pandoc custom reader, writer, filter, and template for A2ML (Attested Markup Language) - AI agent identity and attestation format.
+  - [pandoc-k9](https://github.com/hyperpolymath/pandoc-k9) - Pandoc custom reader, writer, filter, and template for K9 (Self-Validating Components) - configuration with Nickel contracts and trust levels.
 
 
 ### Humanize


### PR DESCRIPTION
Adds two Pandoc custom reader/writer/filter/template packages to the **Parsing and Serialization** section under a new "Pandoc Filters" sub-group:

- **[pandoc-a2ml](https://github.com/hyperpolymath/pandoc-a2ml)** — A2ML (Attested Markup Language) is a format for AI agent identity and attestation. This package provides Pandoc Lua custom reader, writer, filter, and template.
- **[pandoc-k9](https://github.com/hyperpolymath/pandoc-k9)** — K9 (Self-Validating Components) is a configuration format using Nickel contracts and trust levels. This package provides Pandoc Lua custom reader, writer, filter, and template.

Both are Lua-based Pandoc filters that fit naturally alongside the existing `lunamark` entry in this section.